### PR TITLE
HW-264: Reduce the width for template preview jQuery Dialog

### DIFF
--- a/ang/crmMosaico/MixinCtrl.js
+++ b/ang/crmMosaico/MixinCtrl.js
@@ -80,7 +80,7 @@
 
               var model = {mailing: $scope.mailing, attachments: $scope.attachments};
               var options = CRM.utils.adjustDialogDefaults(angular.extend(
-                {autoOpen: false, title: ts('Preview/ Test')},
+                {autoOpen: false, title: ts('Preview/ Test'), width: 550},
                 options
               ));
               var pr = dialogService.open('crmMosaicoPreviewDialog', '~/crmMosaico/PreviewDialogCtrl.html', model, options);


### PR DESCRIPTION
Reduce the width for jQuery Dialog in template page 

Before:
![screen shot 2017-04-05 at 3 24 59 pm](https://cloud.githubusercontent.com/assets/2423218/24707482/0a360986-1a14-11e7-80ac-c9ac5de4789c.png)


After:
![screen shot 2017-04-05 at 1 52 26 pm](https://cloud.githubusercontent.com/assets/2423218/24707419/d328b4fc-1a13-11e7-97e6-14627312f9dd.png)
