### PR TITLE
HW-264: Improving schedule page structure

### DIFF
--- a/ang/crmMosaico/BlockSchedule.html
+++ b/ang/crmMosaico/BlockSchedule.html
@@ -4,12 +4,15 @@
 
   <div class="crmMosaico-schedule-inner form-inline form-inline-tabs" ng-init="selectedTab = 'sendNow'">
     <div class="form-group" ng-class="{'active':schedule.mode === 'now'}" ng-click="selectedTab = 'sendNow'; schedule.mode = 'now'">
-      <input ng-model="schedule.mode" type="radio" name="send" value="now" id="schedule-send-now" ng-checked="selectedTab === 'sendNow'" />
-      <label for="schedule-send-now">{{ts('Send immediately')}}</label>
-    </div>
-    <div class="form-group" ng-class="{'active':schedule.mode === 'at'}" ng-click="selectedTab = 'sendAt'; schedule.mode = 'at'">
-      <input ng-model="schedule.mode" type="radio" name="send" value="at" id="schedule-send-at" ng-checked="selectedTab === 'sendAt'" />
-      <label for="schedule-send-at">{{ts('Send on..')}}</label>
+      <div class="radio">
+        <input ng-model="schedule.mode" type="radio" name="send" value="now" id="schedule-send-now" ng-checked="selectedTab === 'sendNow'" />
+        <label for="schedule-send-now">{{ts('Send immediately')}}</label>
+      </div>
+    </div><div class="form-group" ng-class="{'active':schedule.mode === 'at'}" ng-click="selectedTab = 'sendAt'; schedule.mode = 'at'">
+      <div class="radio">
+        <input ng-model="schedule.mode" type="radio" name="send" value="at" id="schedule-send-at" ng-checked="selectedTab === 'sendAt'" />
+        <label for="schedule-send-at">{{ts('Send on..')}}</label>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
As per my discussion with @AkA84 we have to do some changes in Mosaico schedule page to make it following bootstrap standard and remove the space between form-inline group

Before:
![screen shot 2017-04-06 at 11 05 15 am](https://cloud.githubusercontent.com/assets/2423218/24765392/e6eea26e-1af7-11e7-8ca3-7a6a4ebbd7b3.png)


After:
![screen shot 2017-04-06 at 11 05 37 am](https://cloud.githubusercontent.com/assets/2423218/24765403/ee24cf40-1af7-11e7-82a7-bd19a0f0e5c0.png)



Reference for the solution Solution 
https://css-tricks.com/fighting-the-space-between-inline-block-elements/