### PR TITLE
HW-287: Giving the appropriate active class and remove aria-expanded

### DIFF
--- a/ang/crmMosaico/AdvancedDialogCtrl.html
+++ b/ang/crmMosaico/AdvancedDialogCtrl.html
@@ -5,15 +5,15 @@
 
       <div class="panel-subheading">
         <ul class="nav nav-tabs">
-          <li class="active"><a href="#attachments" data-toggle="tab" aria-expanded="false">{{ts('Attachments')}}</a></li>
-          <li class=""><a href="#responses" data-toggle="tab" aria-expanded="false">{{ts('Responses')}}</a></li>
-          <li class=""><a href="#tracking" data-toggle="tab" aria-expanded="true">{{ts('Tracking')}}</a></li>
+          <li class="active"><a href="#attachments" data-toggle="tab">{{ts('Attachments')}}</a></li>
+          <li class=""><a href="#responses" data-toggle="tab">{{ts('Responses')}}</a></li>
+          <li class=""><a href="#tracking" data-toggle="tab">{{ts('Tracking')}}</a></li>
           <li><a href="#publication" data-toggle="tab">{{ts('Publication')}}</a></li>
         </ul>
       </div>
 
       <div class="tab-content">
-        <div class="tab-pane" id="attachments">
+        <div class="tab-pane active" id="attachments">
           <div crm-attachments="model.attachments" class="form-group"></div>
         </div>
 
@@ -21,7 +21,7 @@
           <div crm-mailing-block-responses crm-mailing="model.mailing" class="form-group"></div>
         </div>
 
-        <div class="tab-pane active" id="tracking">
+        <div class="tab-pane" id="tracking">
           <div crm-mailing-block-tracking crm-mailing="model.mailing" class="form-group"></div>
         </div>
 


### PR DESCRIPTION
"Attachments" tab doesn't seem to be printed well. This was related to correctly adding "active" class to nav-tabs 


Before:
<img width="730" alt="before" src="https://cloud.githubusercontent.com/assets/2423218/25284275/ce690b56-26b6-11e7-9541-3dc1dc0259d8.png">


After:
![after](https://cloud.githubusercontent.com/assets/2423218/25284278/d1eea36c-26b6-11e7-8edd-cffe3c959978.png)
