### PR TITLE
HW-281: Change allowClear to false in Reply-to field

### DIFF
--- a/ang/crmMosaico/BlockMailing.html
+++ b/ang/crmMosaico/BlockMailing.html
@@ -42,7 +42,7 @@
       <select
           id="inputReplyTo"
           class="form-control"
-          crm-ui-select="{dropdownAutoWidth : true, allowClear: true, placeholder: ts('Email address')}"
+          crm-ui-select="{dropdownAutoWidth : true, allowClear: false, placeholder: ts('Email address')}"
           name="replyTo"
           ng-change="checkReplyToChange(mailing)"
           ng-model="mailing.replyto_email"


### PR DESCRIPTION
Remove allowClear option in select2 widget for "Reply-to" field 

Before: 
![screen shot 2017-04-24 at 3 27 27 pm](https://cloud.githubusercontent.com/assets/2423218/25339287/77100744-2902-11e7-8bd7-4e31c8338748.png)


After:
![screen shot 2017-04-24 at 3 27 06 pm](https://cloud.githubusercontent.com/assets/2423218/25339292/7aa25768-2902-11e7-8cf3-7ddcc384a02f.png)
