### PR TITLE
HW-297: Set bootstrap wizard as default while installing mosaico

### DIFF
--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -81,7 +81,7 @@ function do_gencode() {
 }
 
 ##############################
-function default_settings() {
+function set_default_settings() {
   cv api setting.create mosaico_layout=bootstrap-wizard
 }
 
@@ -103,7 +103,7 @@ function do_download() {
     fi
     npm install
     grunt build
-    default_settings
+    set_default_settings
   popd >> /dev/null
 }
 

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -81,6 +81,11 @@ function do_gencode() {
 }
 
 ##############################
+function default_settings() {
+  cv api setting.create mosaico_layout=bootstrap-wizard
+}
+
+##############################
 function do_download() {
   if [ ! -d "$EXTROOT/packages" ]; then
     mkdir "$EXTROOT/packages"
@@ -98,6 +103,7 @@ function do_download() {
     fi
     npm install
     grunt build
+    default_settings
   popd >> /dev/null
 }
 


### PR DESCRIPTION
Set "bootstrap-wizard" as default value while installing Mosaico extension using 

```
./bin/setup.sh -D
```

I created a new function **default_settings** that should handle any default settings commands including the following command, which set bootstrap-wizard as default

```
 cv api setting.create mosaico_layout=bootstrap-wizard
```

This **default_settings** function is executed at the end of **do_download** function 
