### PR TITLE
HW-297: Sets settings when installing Mosaico extension

### DIFF
--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -81,11 +81,6 @@ function do_gencode() {
 }
 
 ##############################
-function set_default_settings() {
-  cv api setting.create mosaico_layout=bootstrap-wizard
-}
-
-##############################
 function do_download() {
   if [ ! -d "$EXTROOT/packages" ]; then
     mkdir "$EXTROOT/packages"
@@ -103,7 +98,6 @@ function do_download() {
     fi
     npm install
     grunt build
-    set_default_settings
   popd >> /dev/null
 }
 

--- a/mosaico.php
+++ b/mosaico.php
@@ -38,8 +38,8 @@ function mosaico_civicrm_install() {
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_postInstall
  */
 function mosaico_civicrm_postInstall() {
-  _mosaico_civix_civicrm_postInstall();
   _mosaico_civicrm_install_settings();
+  _mosaico_civix_civicrm_postInstall();
 }
 
 /**

--- a/mosaico.php
+++ b/mosaico.php
@@ -39,6 +39,7 @@ function mosaico_civicrm_install() {
  */
 function mosaico_civicrm_postInstall() {
   _mosaico_civix_civicrm_postInstall();
+  _mosaico_civicrm_install_settings();
 }
 
 /**
@@ -352,4 +353,11 @@ function mosaico_civicrm_container(\Symfony\Component\DependencyInjection\Contai
   }
   require_once 'CRM/Mosaico/Services.php';
   CRM_Mosaico_Services::registerServices($container);
+}
+
+/**
+* Sets default settings when installing mosaico extension
+*/
+function _mosaico_civicrm_install_settings() {
+  civicrm_api3('Setting', 'create', array('mosaico_layout' => 'bootstrap-wizard'));
 }


### PR DESCRIPTION
Set default layout to 'bootstrap-wizard' when through hook_civicrm_postInstall instead of using cv command
